### PR TITLE
use homeassistant.core_config.Config for 2025.11 (we're in advance)

### DIFF
--- a/custom_components/veolia/__init__.py
+++ b/custom_components/veolia/__init__.py
@@ -7,7 +7,8 @@ from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core_config import Config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed


### PR DESCRIPTION
There's this error (HA Core 2025.1 and Python 3.13 :

`2024-12-26 15:39:57.073 WARNING (ImportExecutor_0) [homeassistant.core] Config was used from veolia, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'veolia' custom integration
`